### PR TITLE
Experimental quality option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,24 @@ Wafer-thin wrapper around the QuickLook `QLThumbnailImageCreate()` API.
 
 ```
 $ git clone [...]
-cd ql-thumbnail
-make
+$ cd ql-thumbnail
+$ make
 ```
 
 ## Usage
 
 ```
-./ql-thumbnail <sourcefile> <destination_thumbnailfile> <type> <width> <height>
+./ql-thumbnail <sourcefile> <destination_thumbnailfile> <type> <width> <height> [quality]
 ./ql-thumbnail image.pdf image.png public.png 1024 1024
 ./ql-thumbnail sourcecode.cpp thumbnails/sourcecode.png public.jpeg 128 512
+./ql-thumbnail nasa.jpg nasa-thumb.jpg public.jpeg 128 128 0.1
 ```
 
 ### Notes
 
 - Size (width/height) values are upper bounds. A smaller thumbnail might be returned.
 - Destination folder for output thumbnail image must exist.
+- Quality parameter is optional, defaults to 1.0 (no compression).
 
 ### Supported output formats
 

--- a/ql-thumbnail.cpp
+++ b/ql-thumbnail.cpp
@@ -4,75 +4,87 @@
 #include <cassert>
 #include <iostream>
 
-
 class Thumbnail {
 public:
-	explicit Thumbnail(const std::string& filename);
-	void save(const std::string& thumbnail_name,
-		const std::string& type, unsigned int width, unsigned int height) const;
+  explicit Thumbnail(const std::string& filename);
+  bool save(const std::string& thumbnail_name, const std::string& type, unsigned int width, unsigned int height, float compression_quality = 1.0f) const;
 private:
-	std::string filename_;
+  std::string filename_;
 };
 
 Thumbnail::Thumbnail(const std::string& filename) {
-	assert(filename.size() > 0);
-	filename_ = filename;
+  assert(filename.size() > 0);
+  filename_ = filename;
 }
 
-void Thumbnail::save(const std::string& thumbnail_name, const std::string& type,
-		unsigned int width, unsigned int height) const {
+bool Thumbnail::save(const std::string& thumbnail_name, const std::string& type, unsigned int width, unsigned int height, float compression_quality) const {
+  bool res {false};
+  CFStringRef type_str_ {nullptr};
+  CFStringRef file_str_ {nullptr};
+  CFURLRef file_url_ {nullptr};
+  CFStringRef thumb_str_ {nullptr};
+  CFURLRef thumb_url_ {nullptr};
+  CGImageRef image_ {nullptr};
+  CGImageDestinationRef thumbnail_ {nullptr};
+  CFDictionaryRef properties_ {nullptr};
+  CFStringRef property_names[1];
+  CFTypeRef property_values[1];
+  property_names[0] = kCGImageDestinationLossyCompressionQuality;
+  property_values[0] = CFNumberCreate(nullptr, kCFNumberFloatType, &compression_quality);
+  properties_ = CFDictionaryCreate(nullptr, (const void **)property_names, (const void **)property_values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 
-	CFStringRef type_str_ {nullptr};
-	CFStringRef file_str_ {nullptr};
-	CFURLRef file_url_ {nullptr};
-	CFStringRef thumb_str_ {nullptr};
-	CFURLRef thumb_url_ {nullptr};
-	CGImageRef image_ {nullptr};
-	CGImageDestinationRef thumbnail_ {nullptr};
+  CGSize size = CGSizeMake(width, height);
 
-	CGSize size = CGSizeMake(width, height);
+  type_str_ = CFStringCreateWithCString(nullptr, type.c_str(), kCFStringEncodingUTF8);
 
-	type_str_ = CFStringCreateWithCString(nullptr, type.c_str(), kCFStringEncodingUTF8);
+  file_str_ = CFStringCreateWithCString(nullptr, filename_.c_str(), kCFStringEncodingUTF8);
+  file_url_ =  CFURLCreateWithFileSystemPath(nullptr, file_str_, kCFURLPOSIXPathStyle, 0);
 
-	file_str_ = CFStringCreateWithCString(nullptr, filename_.c_str(), kCFStringEncodingUTF8);
-	file_url_ =  CFURLCreateWithFileSystemPath(nullptr, file_str_, kCFURLPOSIXPathStyle, 0);
+  thumb_str_ = CFStringCreateWithCString(nullptr, thumbnail_name.c_str(), kCFStringEncodingUTF8);
+  thumb_url_ = CFURLCreateWithFileSystemPath(nullptr, thumb_str_, kCFURLPOSIXPathStyle, 0);
 
-	thumb_str_ = CFStringCreateWithCString(nullptr, thumbnail_name.c_str(), kCFStringEncodingUTF8);
-	thumb_url_ = CFURLCreateWithFileSystemPath(nullptr, thumb_str_, kCFURLPOSIXPathStyle, 0);
+  image_ = QLThumbnailImageCreate(kCFAllocatorDefault, file_url_, size, nullptr);
+  if (image_) {
+    thumbnail_ = CGImageDestinationCreateWithURL(thumb_url_, type_str_, 1, nullptr);
+    if (thumbnail_) {
+      CGImageDestinationAddImage(thumbnail_, image_, properties_);
+      res = CGImageDestinationFinalize(thumbnail_);
+    }
+  }
 
-	image_ = QLThumbnailImageCreate(kCFAllocatorDefault, file_url_, size, nullptr);
-	if (image_) {
-		thumbnail_ = CGImageDestinationCreateWithURL(thumb_url_, type_str_, 1, nullptr);
-		CGImageDestinationAddImage(thumbnail_, image_, nullptr);
-		CGImageDestinationFinalize(thumbnail_);
-	}
-
-	// clean up CoreFoundation gunk
-	if (type_str_) CFRelease(type_str_);
-	if (file_str_) CFRelease(file_str_);
-	if (file_url_) CFRelease(file_url_);
-	if (thumb_str_) CFRelease(thumb_str_);
-	if (thumb_url_) CFRelease(thumb_url_);
-	if (image_) CFRelease(image_);
-	if (thumbnail_) CFRelease(thumbnail_);
+  // clean up CoreFoundation gunk
+  if (type_str_) CFRelease(type_str_);
+  if (file_str_) CFRelease(file_str_);
+  if (file_url_) CFRelease(file_url_);
+  if (thumb_str_) CFRelease(thumb_str_);
+  if (thumb_url_) CFRelease(thumb_url_);
+  if (image_) CFRelease(image_);
+  if (thumbnail_) CFRelease(thumbnail_);
+  if (properties_) CFRelease(properties_);
+  if (property_values[0]) CFRelease(property_values[0]);
+  return res;
 }
 
 int main(int argc, char *argv[]) {
 
-	if (argc == 6) {
-		std::string src {argv[1]};
-		std::string dest {argv[2]};
-		std::string type {argv[3]};
-		std::string width_str {argv[4]};
-        unsigned int width = std::stoi(width_str);
-		std::string height_str {argv[5]};
-        unsigned int height = std::stoi(height_str);
-		Thumbnail thumbnail {src};
-		thumbnail.save(dest, type, width, height);
-	}
-	else {
-		std::string binary {argv[0]};
-		std::cout << "Usage:\n" + binary + " source destination type width height\n";
-	}
-	return 0;
+  if (argc >= 6) {
+    std::string src {argv[1]};
+    std::string dest {argv[2]};
+    std::string type {argv[3]};
+    std::string width_str {argv[4]};
+    unsigned int width = std::stoi(width_str);
+    std::string height_str {argv[5]};
+    unsigned int height = std::stoi(height_str);
+    Thumbnail thumbnail {src};
+    float quality = (argc == 7) ? std::stof(argv[6]) : 1.0f;
+    bool res = thumbnail.save(dest, type, width, height, quality);
+    if (!res) {
+      std::cerr << "Error generating thumbnail" << std::endl;
+    }
+  }
+  else {
+    std::string binary {argv[0]};
+    std::cout << "Usage:\n" + binary + " source destination type width height [quality]" << std::endl;
+  }
+  return 0;
 }


### PR DESCRIPTION
Adds optional quality option for destination formats that support lossy compression:

```
$ ./ql-thumbnail test.jpg thumb-hq.jpg public.jpeg 256 256 1.0

```

![thumb-hq](https://user-images.githubusercontent.com/62911/27395731-14db63ac-56b1-11e7-89ee-3356d85e3ca9.jpg)

```
$ ./ql-thumbnail test.jpg thumb-lq.jpg public.jpeg 256 256 0.05
```

![thumb-lq](https://user-images.githubusercontent.com/62911/27395735-17959982-56b1-11e7-82b2-4aab4a64ff41.jpg)

``` 
$ ls -l thumb* | awk '{print $9 "\t" $5}'
thumb-hq.jpg	61077
thumb-lq.jpg	3398
```